### PR TITLE
Make mural compile under g++ 4.3 and up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
 mural_server: *.cpp *.h
-	/usr/bin/g++ -Wall -O3  -lrt *.cpp -o mural_server
+	/usr/bin/g++ -Wall -O3 *.cpp -lrt -o mural_server
 
 

--- a/mural_server.cpp
+++ b/mural_server.cpp
@@ -2,6 +2,8 @@
 using namespace std;
 
 #include <iostream>
+#include <cstdlib>
+#include <stdio.h>
 #include <string>
 #include <vector>
 #include <sstream>

--- a/tags.cpp
+++ b/tags.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <iostream>
 #include <unistd.h>
+#include <cstdlib>
 
 #include "tags.h"
 


### PR DESCRIPTION
Add some #includes, put -lrt after the source files, etc.
