### PR TITLE
Enable running mural as a remote process

### DIFF
--- a/mural.el
+++ b/mural.el
@@ -69,9 +69,8 @@
                        ;; (fixed in 2.3, but old version is still shipping with Emacs)
                        (generate-new-buffer "*muralserver*")
                        mural-server-path localname))
-                  (progn
                     (start-process
-                     "mural" "*muralserver*" mural-server-path tagfile)))))
+                     "mural" "*muralserver*" mural-server-path tagfile))))
       (set-process-query-on-exit-flag proc nil)
       (set-process-filter
        proc


### PR DESCRIPTION
When tagfile is a tramp path like "/sshx:whatever:/path/to/foo" we startup a remote mural process using `start-file-process` which infers how and where to run the process via default-directory. We pass the localname "/path/to/foo" to the mural process since it's now running remotely. magic